### PR TITLE
Fix: #84 adding missing channel title field

### DIFF
--- a/channels.php
+++ b/channels.php
@@ -339,7 +339,9 @@
             $about['stats'] = $stats;
 
             $description = $resultCommon['description']['simpleText'];
+            $title = $resultCommon['title']['simpleText'];
             $about['description'] = $description;
+            $about['title'] = $title;
 
             $details = [];
             $details['location'] = $resultCommon['country']['simpleText'];


### PR DESCRIPTION
fixes #84 

tested with multipel channel IDs, results look like this:

/channels?part=about&id=UC-lHJZR3Gqxm24_Vd_AJ5Yw

returns:

"title": "PewDiePie",