### PR TITLE
Solving #98 - non-uniform array size

### DIFF
--- a/channels.php
+++ b/channels.php
@@ -273,7 +273,7 @@
                 array_push($community, $post);
             }
             $item['community'] = $community;
-            $item['nextPageToken'] = str_replace('%3D', '=', $contents[10]['continuationItemRenderer']['continuationEndpoint']['continuationCommand']['token']);
+            $item['nextPageToken'] = str_replace('%3D', '=', end($contents)['continuationItemRenderer']['continuationEndpoint']['continuationCommand']['token']);
         }
 
         if ($options['channels']) {


### PR DESCRIPTION
The issue was that after the first couple of requests, the array changed size (from the standard 10 block) to some other variant, while the last item contains the `nextPageToken` it wasn't correctly accessed.