### PR TITLE
fix: deny access to keys.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+ytPrivate/keys.txt

--- a/configuration.php
+++ b/configuration.php
@@ -1,6 +1,6 @@
 <?php
 
-    define('KEYS_FILE', '/var/www/ytPrivate/keys.txt');
+    define('KEYS_FILE', 'ytPrivate/keys.txt');
     define('SERVER_NAME', 'my instance');
     define('GOOGLE_ABUSE_EXEMPTION', '');
     // Can be generated with `tr -dc A-Za-z0-9 </dev/urandom | head -c 32 ; echo ''`.

--- a/ytPrivate/.htaccess
+++ b/ytPrivate/.htaccess
@@ -1,0 +1,4 @@
+<FilesMatch "keys.txt">
+Order allow,deny
+Deny from all
+</FilesMatch>

--- a/ytPrivate/.htaccess
+++ b/ytPrivate/.htaccess
@@ -1,4 +1,3 @@
 <FilesMatch "keys.txt">
-Order allow,deny
-Deny from all
+    Deny from all
 </FilesMatch>


### PR DESCRIPTION
This adds `ytPrivate/.htaccess` to prevent serving the `keys.txt` file.

`ytPrivate/keys.txt` was also added to the `.gitignore` to prevent committing the file.