### PR TITLE
Correct warnings in `videos.php`

### DIFF
--- a/videos.php
+++ b/videos.php
@@ -2,6 +2,8 @@
 
     header('Content-Type: application/json; charset=UTF-8');
 
+    include_once 'common.php';
+
     $videosTests = [
         ['part=id&clipId=UgkxU2HSeGL_NvmDJ-nQJrlLwllwMDBdGZFs', 'items/0/videoId', 'NiXD4xVJM5Y'],
         ['part=clip&clipId=UgkxU2HSeGL_NvmDJ-nQJrlLwllwMDBdGZFs', 'items/0/clip', json_decode(file_get_contents('tests/part=clip&clipId=UgkxU2HSeGL_NvmDJ-nQJrlLwllwMDBdGZFs.json'), true)],
@@ -32,8 +34,6 @@
         ['part=explicitLyrics&id=Ehoe35hTbuY', 'items/0/explicitLyrics', false],
         ['part=explicitLyrics&id=PvM79DJ2PmM', 'items/0/explicitLyrics', true],
     ];
-
-    include_once 'common.php';
 
     $realOptions = [
         'id',


### PR DESCRIPTION
This is stops warnings from appearing in the response to the API call. This is similar to the fix in https://github.com/pw1602/YouTube-operational-API/commit/a951783a3f267ad957f1c4a890da6c2c536d4d39 